### PR TITLE
Increase speed of Genome.distance

### DIFF
--- a/src/nl/sandergielisse/mythan/internal/genes/Genome.java
+++ b/src/nl/sandergielisse/mythan/internal/genes/Genome.java
@@ -417,6 +417,7 @@ public class Genome implements Cloneable, Network {
 		double disjoint = 0; // use double so it won't be used as an int in the formula
 		double excess = 0; // use double so it won't be used as an int in the formula
 
+		List<Double> weights = new ArrayList<>();
 		for (int i = 1; i <= longestLength; i++) {
 			Gene aa = longest.getGene(i);
 			Gene bb = shortest.getGene(i);
@@ -430,13 +431,6 @@ public class Genome implements Cloneable, Network {
 					excess++;
 				}
 			}
-		}
-
-		List<Double> weights = new ArrayList<>();
-		for (int i = 1; i <= longestLength; i++) {
-			Gene aa = longest.getGene(i);
-			Gene bb = shortest.getGene(i);
-
 			if (aa != null && bb != null) {
 				// matching gene
 				double distance = Math.abs(aa.getWeight() - bb.getWeight());


### PR DESCRIPTION
According to the profiler, Genome.getGene was taking up to 69% of the cpu
time. By combining the 2 for loops together, we can save 50% of the calls
to getGene, and therefore increasing the speedup to only 47.3% of the cpu
time.
